### PR TITLE
Add weekly dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Hi! Thanks for creating this fork, the maintainer of the original crate is not responsive at all :cry: .

---

This adds a weekly dependabot job to the repository to update its dependencies.

---

Would you like to share maintainance of this crate? I'd love to help out (passively at least). I would like to add dependabot (this PR) and bors as a mergebot. If you don't have any interest in maintaining this further, I would love to take over completely. You can transfer this repository to me and give me access to publishing on crates.io if you want!