### PR TITLE
Cargo clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,21 @@ jobs:
           args: --all --all-features
 
 
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.60.0
+          override: true
+      - uses: swatinem/rust-cache@v1
+      - run: rustup component add clippy
+      - name: cargo-clippy
+        run: cargo clippy --all --all-targets --all-features -- -D warnings
+
+
   # We need some "accummulation" job here because bors fails (timeouts) to
   # listen on matrix builds.
   # Hence, we have some kind of dummy here that bors can listen on
@@ -84,6 +99,7 @@ jobs:
     if: ${{ success() }}
     needs:
       - check
+      - clippy
       - fmt
       - test
     runs-on: ubuntu-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,8 @@ impl Preprocessor for Bob {
                 // of many different Text blocks, thus we need to buffer them in here
                 // see https://github.com/raphlinus/pulldown-cmark/issues/507
                 let mut diagram = String::new();
-                let events = Parser::new_ext(&chapter.content, Options::all())
-                    .map(|event| {
+                let events =
+                    Parser::new_ext(&chapter.content, Options::all()).filter_map(|event| {
                         match (&event, in_block) {
                             // check if we are entering a svgbob codeblock
                             (
@@ -107,9 +107,7 @@ impl Preprocessor for Bob {
                             // if nothing matches, change nothing
                             _ => Some(event),
                         }
-                    })
-                    // flatten to fullfill the Trait boundaries of the cmark call below
-                    .flatten();
+                    });
 
                 // create a buffer in which we can place the markdown
                 let mut buf = String::with_capacity(chapter.content.len() + 128);


### PR DESCRIPTION
Adds cargo-clippy CI job and fixes the one warning we get.