### PR TITLE
Cargo deny

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
     strategy:
       matrix:
         checks:
-          - advisories
           - bans licenses sources
 
     # Prevent sudden announcement of a new advisory from failing ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,26 @@ jobs:
           command: check
 
 
+  deny:
+    name: deny
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: cargo-deny
+      uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check ${{ matrix.checks }}
+
+
   fmt:
     name: format
     runs-on: ubuntu-latest
@@ -100,6 +120,7 @@ jobs:
     needs:
       - check
       - clippy
+      - deny
       - fmt
       - test
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,70 @@
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.7 short identifier (+ optional exception)].
+allow = []
+
+# List of explicitly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.7 short identifier (+ optional exception)].
+deny = []
+
+# The lint level for licenses considered copyleft
+copyleft = "deny"
+
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will only be approved if it is both OSI-approved *AND* FSF/Free
+# * either - The license will be approved if it is either OSI-approved *OR* FSF/Free
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF/Free
+# * fsf-only - The license will be approved if is FSF/Free *AND NOT* OSI-approved
+# * neither - The license will be denied if is FSF/Free *OR* OSI-approved
+allow-osi-fsf-free = "either"
+
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+
+exceptions = [
+]
+
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+
+# List of crates that are allowed. Use with care!
+allow = [
+]
+
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+]
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+]
+
+# Similarly to `skip` allows you to skip certain crates during duplicate detection,
+# unlike skip, it also includes the entire tree of transitive dependencies starting at
+# the specified crate, up to a certain depth, which is by default infinite
+skip-tree = [
+]
+
+
+[advisories]
+ignore = [
+]
+

--- a/deny.toml
+++ b/deny.toml
@@ -5,7 +5,7 @@ unlicensed = "deny"
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
-allow = []
+allow = ["MPL-2.0"]
 
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses


### PR DESCRIPTION
Adds a cargo-deny job and the configuration for the tool.

<details>

Should wait until the first PRs from dependabot roll in, as we get an advisory for the "time" crate

</details>