### PR TITLE
Change cargo.toml to book.toml in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cargo install --git https://github.com/matthiasbeyer/mdbook-svgbob2.git
 
 ## Usage
 
-Add this to your cargo.toml:
+Add this to your book.toml:
 ```toml
 [preprocessor.svgbob2]
 ```


### PR DESCRIPTION
The preprocessor needs to be configured in `book.toml` and not in `cargo.toml`. This PR changes this accordingly.